### PR TITLE
doc (gitignore): add Claude Code entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build-html-wrap.sh
 .DS_Store
 .vscode/*
 *.code-workspace
+CLAUDE.md
+.claude/


### PR DESCRIPTION
Type: doc
Section: gitignore

## Summary
- Add `CLAUDE.md` to .gitignore for local Claude Code guidance
- Add `.claude/` directory to .gitignore for Claude Code settings

## Test plan
- [x] Verify `.gitignore` excludes the new entries